### PR TITLE
Fix build due to missing reference and capitalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ ifndef GPL
 else
     SRCS += dosbox/dbopl.cpp
 endif
-SRCS += sdl_wrap.c
 SRCS += id_ca.c
 SRCS += id_in.c
 SRCS += id_pm.c

--- a/wl_game.c
+++ b/wl_game.c
@@ -1,7 +1,7 @@
 // WL_GAME.C
 
 #include "wl_def.h"
-#include <SDL_Mixer.h>
+#include <SDL_mixer.h>
 
 /*
 =============================================================================


### PR DESCRIPTION
With the removal of SDL 1.2 support, there was a leftover reference to `sdl_wrap.c` preventing the build from completing. There was also a reference to `SDL_Mixer.h`, where in case-sensitive systems it should be `SDL_mixer.h` (lowercase "m").